### PR TITLE
feat(clean): 非アクティブなリポジトリを丸ごと削除 (デフォルト15日)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage:
   gh q get <repo>     ... Clone a repository into ~/ghq/github.com
   gh q list           ... List all repositories in ~/ghq/github.com
   gh q clean [--days N] [--dry-run]
-                     ... Delete entire repos inactive for N days (default 15) under ~/ghq
+                     ... Delete repos with no local activity for N days (default 15) under ~/ghq
   gh q -- <command>   ... Search via fzf and run <command> in the selected directory
   gh q <command>      ... Search via fzf and run <command> with selected directory as argument
 
@@ -25,7 +25,7 @@ Usage:
   gh q get <repo>     ... リポジトリを~/ghq/github.comにクローン
   gh q list           ... ~/ghq/github.comにある全リポジトリを表示
   gh q clean [--days N] [--dry-run]
-                     ... リポジトリ単位で削除: 最終活動がN日以上前のリポジトリを丸ごと削除 (デフォルト15日)
+                     ... ローカル活動がN日以上ないリポジトリを ~/ghq から削除 (デフォルト15日)
   gh q -- <command>   ... fzfで検索し、選択したディレクトリで<command>を実行
   gh q <command>      ... fzfで検索し、選択したディレクトリを引数として<command>を実行
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ gh q --help
 Usage:
   gh q get <repo>     ... Clone a repository into ~/ghq/github.com
   gh q list           ... List all repositories in ~/ghq/github.com
+  gh q clean [--days N] [--dry-run]
+                     ... Clean generated artifacts in ~/ghq older than N days (default 15)
   gh q -- <command>   ... Search via fzf and run <command> in the selected directory
   gh q <command>      ... Search via fzf and run <command> with selected directory as argument
 
@@ -22,6 +24,8 @@ $ gh q --help
 Usage:
   gh q get <repo>     ... リポジトリを~/ghq/github.comにクローン
   gh q list           ... ~/ghq/github.comにある全リポジトリを表示
+  gh q clean [--days N] [--dry-run]
+                     ... ~/ghq配下の生成物をN日より古いものだけ削除 (デフォルト15日)
   gh q -- <command>   ... fzfで検索し、選択したディレクトリで<command>を実行
   gh q <command>      ... fzfで検索し、選択したディレクトリを引数として<command>を実行
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage:
   gh q get <repo>     ... Clone a repository into ~/ghq/github.com
   gh q list           ... List all repositories in ~/ghq/github.com
   gh q clean [--days N] [--dry-run]
-                     ... Clean generated artifacts in ~/ghq older than N days (default 15)
+                     ... Per-repo cleanup: if repo inactive for N days (default 15), remove generated artifacts inside it
   gh q -- <command>   ... Search via fzf and run <command> in the selected directory
   gh q <command>      ... Search via fzf and run <command> with selected directory as argument
 
@@ -25,7 +25,7 @@ Usage:
   gh q get <repo>     ... リポジトリを~/ghq/github.comにクローン
   gh q list           ... ~/ghq/github.comにある全リポジトリを表示
   gh q clean [--days N] [--dry-run]
-                     ... ~/ghq配下の生成物をN日より古いものだけ削除 (デフォルト15日)
+                     ... リポジトリ単位のクリーン: 最終活動がN日以上前のリポジトリ内の生成物を削除 (デフォルト15日)
   gh q -- <command>   ... fzfで検索し、選択したディレクトリで<command>を実行
   gh q <command>      ... fzfで検索し、選択したディレクトリを引数として<command>を実行
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage:
   gh q get <repo>     ... Clone a repository into ~/ghq/github.com
   gh q list           ... List all repositories in ~/ghq/github.com
   gh q clean [--days N] [--dry-run]
-                     ... Per-repo cleanup: if repo inactive for N days (default 15), remove generated artifacts inside it
+                     ... Delete entire repos inactive for N days (default 15) under ~/ghq
   gh q -- <command>   ... Search via fzf and run <command> in the selected directory
   gh q <command>      ... Search via fzf and run <command> with selected directory as argument
 
@@ -25,7 +25,7 @@ Usage:
   gh q get <repo>     ... リポジトリを~/ghq/github.comにクローン
   gh q list           ... ~/ghq/github.comにある全リポジトリを表示
   gh q clean [--days N] [--dry-run]
-                     ... リポジトリ単位のクリーン: 最終活動がN日以上前のリポジトリ内の生成物を削除 (デフォルト15日)
+                     ... リポジトリ単位で削除: 最終活動がN日以上前のリポジトリを丸ごと削除 (デフォルト15日)
   gh q -- <command>   ... fzfで検索し、選択したディレクトリで<command>を実行
   gh q <command>      ... fzfで検索し、選択したディレクトリを引数として<command>を実行
 ```

--- a/gh-q
+++ b/gh-q
@@ -6,7 +6,7 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "  gh q get <repo>     ... Clone a repository into ~/ghq/github.com"
     echo "  gh q list           ... List all repositories in ~/ghq/github.com"
     echo "  gh q clean [--days N] [--dry-run]"
-    echo "                     ... Per-repo cleanup: if repo inactive for N days (default 15), remove generated artifacts inside it"
+    echo "                     ... Delete entire repos inactive for N days (default 15) under ~/ghq"
     echo "  gh q -- <command>   ... Search via fzf and run <command> in the selected directory"
     echo "  gh q <command>      ... Search via fzf and run <command> with selected directory as argument"
     exit 0
@@ -64,41 +64,6 @@ elif [ "$1" == "clean" ]; then
         echo "Not found: $ROOT" >&2; exit 1
     fi
 
-    TARGETS=(
-        node_modules
-        dist
-        build
-        out
-        .next
-        .nuxt
-        .cache
-        .gradle
-        .terraform
-        target
-        .venv
-        venv
-        .tox
-        __pycache__
-        .pytest_cache
-        .mypy_cache
-        coverage
-        .parcel-cache
-        Pods
-        .yarn
-    )
-
-    name_expr=()
-    for n in "${TARGETS[@]}"; do
-        if [ ${#name_expr[@]} -gt 0 ]; then
-            name_expr+=( -o )
-        fi
-        if [ "$n" = ".yarn" ]; then
-            name_expr+=( \( -path "*/.yarn/cache" -o -path "*/.yarn/unplugged" \) )
-        else
-            name_expr+=( -name "$n" )
-        fi
-    done
-
     # Compute cutoff epoch: now - DAYS*86400 (portable)
     NOW_EPOCH=$(date +%s)
     CUTOFF_EPOCH=$(( NOW_EPOCH - DAYS * 86400 ))
@@ -121,10 +86,9 @@ elif [ "$1" == "clean" ]; then
         fi
     }
 
-    echo "Scanning $ROOT repositories; cleaning those inactive for $DAYS days..."
+    echo "Scanning $ROOT repositories; deleting repos inactive for $DAYS days..."
 
-    REPOS_CLEANED=0
-    DIRS_REMOVED=0
+    REPOS_REMOVED=0
 
     # Reuse gh q list to enumerate repos
     while IFS= read -r repo; do
@@ -136,39 +100,26 @@ elif [ "$1" == "clean" ]; then
             continue
         fi
 
-        # Build list of target directories within this repo
-        mapfile -t candidates < <(eval find "\"$repo\"" -type d \( ${name_expr[@]} \) -prune -print)
-        if [ ${#candidates[@]} -eq 0 ]; then
-            continue
-        fi
-
-        REPOS_CLEANED=$((REPOS_CLEANED+1))
         if [ $DRY_RUN -eq 1 ]; then
-            echo "Repo (inactive): $repo"
-            for d in "${candidates[@]}"; do
-                echo "  would remove: $d"
-            done
+            echo "Would delete repo: $repo"
         else
-            echo "Repo (inactive): $repo"
-            for d in "${candidates[@]}"; do
-                echo "  removing: $d"
-                rm -rf "$d"
-                DIRS_REMOVED=$((DIRS_REMOVED+1))
-            done
+            echo "Deleting repo: $repo"
+            rm -rf "$repo"
+            REPOS_REMOVED=$((REPOS_REMOVED+1))
         fi
     done < <(gh q list)
 
     if [ $DRY_RUN -eq 1 ]; then
-        if [ $REPOS_CLEANED -eq 0 ]; then
-            echo "No inactive repositories found for cleanup."
+        if [ $REPOS_REMOVED -eq 0 ]; then
+            echo "No inactive repositories found for deletion."
         else
-            echo "Dry-run complete. $REPOS_CLEANED repos would be cleaned."
+            echo "Dry-run complete. $REPOS_REMOVED repos would be deleted."
         fi
     else
-        if [ $REPOS_CLEANED -eq 0 ]; then
-            echo "No inactive repositories found for cleanup."
+        if [ $REPOS_REMOVED -eq 0 ]; then
+            echo "No inactive repositories found for deletion."
         else
-            echo "Cleanup complete. Cleaned $REPOS_CLEANED repos, removed $DIRS_REMOVED directories."
+            echo "Cleanup complete. Deleted $REPOS_REMOVED repositories."
         fi
     fi
 

--- a/gh-q
+++ b/gh-q
@@ -5,6 +5,8 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "Usage:"
     echo "  gh q get <repo>     ... Clone a repository into ~/ghq/github.com"
     echo "  gh q list           ... List all repositories in ~/ghq/github.com"
+    echo "  gh q clean [--days N] [--dry-run]"
+    echo "                     ... Clean generated artifacts in ~/ghq older than N days (default 15)"
     echo "  gh q -- <command>   ... Search via fzf and run <command> in the selected directory"
     echo "  gh q <command>      ... Search via fzf and run <command> with selected directory as argument"
     exit 0
@@ -30,6 +32,97 @@ elif [ "$1" == "get" ]; then
 # gh q list
 elif [ "$1" == "list" ]; then
     find ~/ghq -maxdepth 3 -mindepth 3 -type d -not -path '*/\.*' -not -path '*/.git/worktrees*'
+
+
+elif [ "$1" == "clean" ]; then
+    shift
+    DAYS=15
+    DRY_RUN=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --days)
+                if [ -n "$2" ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+                    DAYS="$2"; shift 2
+                else
+                    echo "Error: --days requires an integer argument" >&2; exit 1
+                fi
+                ;;
+            --dry-run)
+                DRY_RUN=1; shift ;;
+            -h|--help)
+                echo "Usage: gh q clean [--days N] [--dry-run]";
+                echo "  Cleans generated artifacts under ~/ghq older than N days (default 15).";
+                echo "  Targets: node_modules, dist, build, out, .next, .nuxt, .cache, .gradle, .terraform, target, .venv, venv, .tox, __pycache__, .pytest_cache, .mypy_cache, coverage, .parcel-cache, .yarn/cache, .yarn/unplugged, Pods";
+                exit 0 ;;
+            *)
+                echo "Unknown option: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    ROOT="$HOME/ghq"
+    if [ ! -d "$ROOT" ]; then
+        echo "Not found: $ROOT" >&2; exit 1
+    fi
+
+    TARGETS=(
+        node_modules
+        dist
+        build
+        out
+        .next
+        .nuxt
+        .cache
+        .gradle
+        .terraform
+        target
+        .venv
+        venv
+        .tox
+        __pycache__
+        .pytest_cache
+        .mypy_cache
+        coverage
+        .parcel-cache
+        Pods
+        .yarn
+    )
+
+    name_expr=()
+    for n in "${TARGETS[@]}"; do
+        if [ ${#name_expr[@]} -gt 0 ]; then
+            name_expr+=( -o )
+        fi
+        if [ "$n" = ".yarn" ]; then
+            name_expr+=( \( -path "*/.yarn/cache" -o -path "*/.yarn/unplugged" \) )
+        else
+            name_expr+=( -name "$n" )
+        fi
+    done
+
+    echo "Scanning $ROOT for generated artifacts older than $DAYS days..."
+
+    if [ $DRY_RUN -eq 1 ]; then
+        eval find "\"$ROOT\"" -type d \( ${name_expr[@]} \) -mtime +"$DAYS" -prune -print
+        exit 0
+    else
+        COUNT=0
+        # Use process substitution to stay in current shell
+        while IFS= read -r d; do
+            # Skip empty lines just in case
+            [ -z "$d" ] && continue
+            if [ $COUNT -eq 0 ]; then
+                echo "Found directories to remove:"
+            fi
+            echo "Removing: $d"
+            rm -rf "$d"
+            COUNT=$((COUNT+1))
+        done < <(eval find "\"$ROOT\"" -type d \( ${name_expr[@]} \) -mtime +"$DAYS" -prune -print)
+        if [ $COUNT -eq 0 ]; then
+            echo "No candidates found."
+        else
+            echo "Cleanup complete. Removed $COUNT directories."
+        fi
+    fi
 
 
 # gh q -- <command>

--- a/gh-q
+++ b/gh-q
@@ -6,7 +6,7 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "  gh q get <repo>     ... Clone a repository into ~/ghq/github.com"
     echo "  gh q list           ... List all repositories in ~/ghq/github.com"
     echo "  gh q clean [--days N] [--dry-run]"
-    echo "                     ... Clean generated artifacts in ~/ghq older than N days (default 15)"
+    echo "                     ... Per-repo cleanup: if repo inactive for N days (default 15), remove generated artifacts inside it"
     echo "  gh q -- <command>   ... Search via fzf and run <command> in the selected directory"
     echo "  gh q <command>      ... Search via fzf and run <command> with selected directory as argument"
     exit 0
@@ -99,28 +99,76 @@ elif [ "$1" == "clean" ]; then
         fi
     done
 
-    echo "Scanning $ROOT for generated artifacts older than $DAYS days..."
+    # Compute cutoff epoch: now - DAYS*86400 (portable)
+    NOW_EPOCH=$(date +%s)
+    CUTOFF_EPOCH=$(( NOW_EPOCH - DAYS * 86400 ))
+
+    # Helper to get repo last activity epoch
+    get_repo_epoch() {
+        local repo="$1"
+        local ts=""
+        ts=$(git -C "$repo" log -1 --format=%ct 2>/dev/null || true)
+        if [ -n "$ts" ]; then
+            echo "$ts"; return 0
+        fi
+        # Fallback to directory mtime (BSD/GNU stat)
+        if stat -f %m "$repo" >/dev/null 2>&1; then
+            stat -f %m "$repo"
+        elif stat -c %Y "$repo" >/dev/null 2>&1; then
+            stat -c %Y "$repo"
+        else
+            echo 0
+        fi
+    }
+
+    echo "Scanning $ROOT repositories; cleaning those inactive for $DAYS days..."
+
+    REPOS_CLEANED=0
+    DIRS_REMOVED=0
+
+    # Reuse gh q list to enumerate repos
+    while IFS= read -r repo; do
+        [ -z "$repo" ] && continue
+        [ -d "$repo/.git" ] || continue
+        last_epoch=$(get_repo_epoch "$repo")
+        # If last activity newer than cutoff, skip repo
+        if [ "$last_epoch" -ge "$CUTOFF_EPOCH" ]; then
+            continue
+        fi
+
+        # Build list of target directories within this repo
+        mapfile -t candidates < <(eval find "\"$repo\"" -type d \( ${name_expr[@]} \) -prune -print)
+        if [ ${#candidates[@]} -eq 0 ]; then
+            continue
+        fi
+
+        REPOS_CLEANED=$((REPOS_CLEANED+1))
+        if [ $DRY_RUN -eq 1 ]; then
+            echo "Repo (inactive): $repo"
+            for d in "${candidates[@]}"; do
+                echo "  would remove: $d"
+            done
+        else
+            echo "Repo (inactive): $repo"
+            for d in "${candidates[@]}"; do
+                echo "  removing: $d"
+                rm -rf "$d"
+                DIRS_REMOVED=$((DIRS_REMOVED+1))
+            done
+        fi
+    done < <(gh q list)
 
     if [ $DRY_RUN -eq 1 ]; then
-        eval find "\"$ROOT\"" -type d \( ${name_expr[@]} \) -mtime +"$DAYS" -prune -print
-        exit 0
-    else
-        COUNT=0
-        # Use process substitution to stay in current shell
-        while IFS= read -r d; do
-            # Skip empty lines just in case
-            [ -z "$d" ] && continue
-            if [ $COUNT -eq 0 ]; then
-                echo "Found directories to remove:"
-            fi
-            echo "Removing: $d"
-            rm -rf "$d"
-            COUNT=$((COUNT+1))
-        done < <(eval find "\"$ROOT\"" -type d \( ${name_expr[@]} \) -mtime +"$DAYS" -prune -print)
-        if [ $COUNT -eq 0 ]; then
-            echo "No candidates found."
+        if [ $REPOS_CLEANED -eq 0 ]; then
+            echo "No inactive repositories found for cleanup."
         else
-            echo "Cleanup complete. Removed $COUNT directories."
+            echo "Dry-run complete. $REPOS_CLEANED repos would be cleaned."
+        fi
+    else
+        if [ $REPOS_CLEANED -eq 0 ]; then
+            echo "No inactive repositories found for cleanup."
+        else
+            echo "Cleanup complete. Cleaned $REPOS_CLEANED repos, removed $DIRS_REMOVED directories."
         fi
     fi
 

--- a/gh-q
+++ b/gh-q
@@ -6,7 +6,7 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "  gh q get <repo>     ... Clone a repository into ~/ghq/github.com"
     echo "  gh q list           ... List all repositories in ~/ghq/github.com"
     echo "  gh q clean [--days N] [--dry-run]"
-    echo "                     ... Delete entire repos inactive for N days (default 15) under ~/ghq"
+    echo "                     ... Delete repos with no local activity for N days (default 15) under ~/ghq"
     echo "  gh q -- <command>   ... Search via fzf and run <command> in the selected directory"
     echo "  gh q <command>      ... Search via fzf and run <command> with selected directory as argument"
     exit 0
@@ -51,8 +51,8 @@ elif [ "$1" == "clean" ]; then
                 DRY_RUN=1; shift ;;
             -h|--help)
                 echo "Usage: gh q clean [--days N] [--dry-run]";
-                echo "  Cleans generated artifacts under ~/ghq older than N days (default 15).";
-                echo "  Targets: node_modules, dist, build, out, .next, .nuxt, .cache, .gradle, .terraform, target, .venv, venv, .tox, __pycache__, .pytest_cache, .mypy_cache, coverage, .parcel-cache, .yarn/cache, .yarn/unplugged, Pods";
+                echo "  Removes git repositories under ~/ghq whose local activity is older than N days (default 15).";
+                echo "  Local activity is based on mtimes of .git metadata such as FETCH_HEAD and index.";
                 exit 0 ;;
             *)
                 echo "Unknown option: $1" >&2; exit 1 ;;
@@ -68,26 +68,26 @@ elif [ "$1" == "clean" ]; then
     NOW_EPOCH=$(date +%s)
     CUTOFF_EPOCH=$(( NOW_EPOCH - DAYS * 86400 ))
 
-    # Helper to get repo last activity epoch
+    # Helper to get repo last local activity epoch
     get_repo_epoch() {
         local repo="$1"
-        local ts=""
-        ts=$(git -C "$repo" log -1 --format=%ct 2>/dev/null || true)
-        if [ -n "$ts" ]; then
-            echo "$ts"; return 0
-        fi
-        # Fallback to directory mtime (BSD/GNU stat)
-        if stat -f %m "$repo" >/dev/null 2>&1; then
-            stat -f %m "$repo"
-        elif stat -c %Y "$repo" >/dev/null 2>&1; then
-            stat -c %Y "$repo"
-        else
-            echo 0
-        fi
+        local candidate=""
+        for candidate in "$repo/.git/FETCH_HEAD" "$repo/.git/index" "$repo/.git/HEAD" "$repo/.git/logs/HEAD" "$repo/.git" "$repo"; do
+            [ -e "$candidate" ] || continue
+            if stat -f %m "$candidate" >/dev/null 2>&1; then
+                stat -f %m "$candidate"
+                return 0
+            elif stat -c %Y "$candidate" >/dev/null 2>&1; then
+                stat -c %Y "$candidate"
+                return 0
+            fi
+        done
+        echo 0
     }
 
     echo "Scanning $ROOT repositories; deleting repos inactive for $DAYS days..."
 
+    REPOS_MARKED=0
     REPOS_REMOVED=0
 
     # Reuse gh q list to enumerate repos
@@ -100,6 +100,8 @@ elif [ "$1" == "clean" ]; then
             continue
         fi
 
+        REPOS_MARKED=$((REPOS_MARKED+1))
+
         if [ $DRY_RUN -eq 1 ]; then
             echo "Would delete repo: $repo"
         else
@@ -110,10 +112,10 @@ elif [ "$1" == "clean" ]; then
     done < <(gh q list)
 
     if [ $DRY_RUN -eq 1 ]; then
-        if [ $REPOS_REMOVED -eq 0 ]; then
+        if [ $REPOS_MARKED -eq 0 ]; then
             echo "No inactive repositories found for deletion."
         else
-            echo "Dry-run complete. $REPOS_REMOVED repos would be deleted."
+            echo "Dry-run complete. $REPOS_MARKED repos would be deleted."
         fi
     else
         if [ $REPOS_REMOVED -eq 0 ]; then


### PR DESCRIPTION
このPRでは、`gh q clean` サブコマンドを追加し、\n\n最終仕様:\n- ghq全体をリストアップし、各リポジトリ単位(`gh q list`の単位)で判定\n- リポジトリの最終活動(最後のコミット時刻)がN日以上前なら、そのリポジトリフォルダを丸ごと削除\n- 既定閾値は15日。`--days N` で変更可\n- `--dry-run` で削除されるリポジトリのみを表示\n- フォルダターゲット指定(`node_modules`等)は行わない\n\n判定ロジック:\n- 可能なら `git log -1 --format=%ct` のepochで判定\n- 取得できない場合はディレクトリmtimeにフォールバック\n- 閾値は現在時刻からN日分(86400秒/日)を減算\n\n使い方:\n- ドライラン: `gh q clean --dry-run`\n- 15日以上非アクティブなリポジトリを削除: `gh q clean`\n- 30日に変更: `gh q clean --days 30`\n