### PR TITLE
feat: add shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ gh extension install HikaruEgashira/gh-q
 gh q get owner/repo
 ```
 
+## Shell Completion
+
+### Zsh
+```bash
+# Add to ~/.zshrc
+source ~/.local/share/gh/extensions/gh-q/completions/_gh-q
+```
+
+### Bash
+```bash
+# Add to ~/.bashrc
+source ~/.local/share/gh/extensions/gh-q/completions/gh-q.bash
+```
+
+### Fish
+```bash
+# Copy to fish completions directory
+cp ~/.local/share/gh/extensions/gh-q/completions/gh-q.fish ~/.config/fish/completions/gh.fish
+```
+
 ## fzf Native Integration
 
 ### Path Argument Mode

--- a/completions/_gh-q
+++ b/completions/_gh-q
@@ -1,0 +1,59 @@
+#compdef _gh_q
+
+# Completion for gh-q (GitHub CLI extension)
+# Usage: Add to fpath and source, or use the wrapper function
+
+_gh_q_repos() {
+  local -a repos
+  repos=(${(f)"$(gh api user/repos --jq '.[].full_name' 2>/dev/null)"})
+  _describe -t repos 'repository' repos
+}
+
+_gh_q_complete() {
+  local context state state_descr line
+  typeset -A opt_args
+
+  _arguments -C \
+    '1: :->command' \
+    '*: :->args'
+
+  case $state in
+    command)
+      local -a commands
+      commands=(
+        'get:Clone a repository'
+        'list:List repositories'
+        '--:Change directory and run command'
+      )
+      _describe -t commands 'command' commands
+      _command_names -e
+      ;;
+    args)
+      case $words[2] in
+        get)
+          _gh_q_repos
+          ;;
+        list)
+          ;;
+        --)
+          shift words
+          (( CURRENT-- ))
+          _normal
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+  esac
+}
+
+# Wrapper function for "gh q" completion
+_gh_q() {
+  # Shift "gh" from words array
+  words=("gh-q" "${words[@]:2}")
+  (( CURRENT-- ))
+  _gh_q_complete
+}
+
+# Register completion
+compdef _gh_q 'gh q'

--- a/completions/gh-q.bash
+++ b/completions/gh-q.bash
@@ -1,0 +1,55 @@
+# Completion for gh-q (GitHub CLI extension)
+# Usage: source this file in ~/.bashrc
+
+_gh_q_repos() {
+  gh api user/repos --jq '.[].full_name' 2>/dev/null
+}
+
+_gh_q_complete() {
+  local cur prev words cword
+  _init_completion || return
+
+  # For "gh q", we need to check position relative to "q"
+  local cmd_index=1
+  if [[ "${words[0]}" == "gh" && "${words[1]}" == "q" ]]; then
+    cmd_index=2
+  fi
+
+  local effective_cword=$((cword - cmd_index + 1))
+
+  if [[ $effective_cword -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "get list --" -- "$cur"))
+    COMPREPLY+=($(compgen -c -- "$cur"))
+    return
+  fi
+
+  case "${words[$cmd_index]}" in
+    get)
+      if [[ $effective_cword -eq 2 ]]; then
+        local repos
+        repos=$(_gh_q_repos)
+        COMPREPLY=($(compgen -W "$repos" -- "$cur"))
+      fi
+      ;;
+    list)
+      ;;
+    --)
+      _command_offset $((cmd_index + 1))
+      ;;
+    *)
+      ;;
+  esac
+}
+
+# Wrapper for "gh q" completion
+_gh_q() {
+  # Check if we're completing "gh q ..."
+  if [[ "${COMP_WORDS[0]}" == "gh" && "${COMP_WORDS[1]}" == "q" ]]; then
+    _gh_q_complete
+  else
+    _gh_q_complete
+  fi
+}
+
+complete -F _gh_q gh-q
+complete -F _gh_q -o default gh q 2>/dev/null || true

--- a/completions/gh-q.fish
+++ b/completions/gh-q.fish
@@ -1,0 +1,34 @@
+# Completion for gh-q (GitHub CLI extension)
+# Usage: Copy to ~/.config/fish/completions/ or source directly
+
+function __gh_q_repos
+    gh api user/repos --jq '.[].full_name' 2>/dev/null
+end
+
+# Check if we're at "gh q <TAB>" (needs subcommand)
+function __gh_q_needs_command
+    set -l cmd (commandline -opc)
+    # For "gh q", cmd[1]=gh, cmd[2]=q
+    if test (count $cmd) -eq 2; and test "$cmd[1]" = "gh"; and test "$cmd[2]" = "q"
+        return 0
+    end
+    return 1
+end
+
+# Check if we're using a specific subcommand
+function __gh_q_using_command
+    set -l cmd (commandline -opc)
+    # For "gh q get", cmd[1]=gh, cmd[2]=q, cmd[3]=get
+    if test (count $cmd) -ge 3; and test "$cmd[1]" = "gh"; and test "$cmd[2]" = "q"; and test "$cmd[3]" = "$argv[1]"
+        return 0
+    end
+    return 1
+end
+
+# Subcommands for "gh q"
+complete -f -c gh -n '__gh_q_needs_command' -a 'get' -d 'Clone a repository'
+complete -f -c gh -n '__gh_q_needs_command' -a 'list' -d 'List repositories'
+complete -f -c gh -n '__gh_q_needs_command' -a '--' -d 'Change directory and run command'
+
+# get subcommand: complete with user repos
+complete -f -c gh -n '__gh_q_using_command get' -a '(__gh_q_repos)'


### PR DESCRIPTION
## 概要

Zsh、Bash、Fish対応のシェル補完機能を追加します。

## 変更内容

### 補完機能
- **サブコマンド補完**: `gh q <TAB>` で `get`, `list`, `--` を補完
- **リポジトリ補完**: `gh q get <TAB>` でユーザーのリポジトリ一覧を補完
- **コマンド補完**: `gh q -- <TAB>` でシステムコマンドを補完

### ファイル追加
- `completions/_gh-q` - Zsh completion スクリプト
- `completions/gh-q.bash` - Bash completion スクリプト
- `completions/gh-q.fish` - Fish completion スクリプト
- `README.md` - インストール手順の追記

## 検証方法

### Zsh
\`\`\`bash
source ~/.local/share/gh/extensions/gh-q/completions/_gh-q
gh q <TAB>  # get, list, -- が表示
gh q get <TAB>  # リポジトリ一覧が表示
\`\`\`

### Bash
\`\`\`bash
source ~/.local/share/gh/extensions/gh-q/completions/gh-q.bash
gh q <TAB>  # get, list, -- が表示
\`\`\`

### Fish
\`\`\`bash
source ~/.local/share/gh/extensions/gh-q/completions/gh-q.fish
gh q <TAB>  # get, list, -- が表示
\`\`\`