### PR TITLE
fix: handle HTTPS URLs without .git suffix in gh q get

### DIFF
--- a/gh-q
+++ b/gh-q
@@ -14,7 +14,7 @@ elif [ "$1" == "get" ]; then
     if [[ "$2" == git@github.com:* || "$2" == https://github.com/* ]]; then
         # ex: git@github.com:owner/repo.git → owner/repo
         # ex: https:github.com/owner/repo.git → owner/repo
-        repo_name=$(echo "$2" | sed -e 's/.*github.com[:\/]\(.*\)\.git/\1/')
+        repo_name=$(echo "$2" | sed -e 's/.*github.com[:\/]//' -e 's/\.git$//' -e 's/\/$//')
         repo_path="$HOME/ghq/github.com/${repo_name}"
     else
         repo_path="$HOME/ghq/github.com/$2"


### PR DESCRIPTION
## 説明

HTTPSフォーマットで`.git`なしのURLを指定した場合、clone pathにURLが含まれたままになるバグを修正しました。

## 修正内容

sedコマンドを複数の処理に分割して、`.git`拡張子がない場合でも正しく処理できるようにしました。

### 修正前
```bash
repo_name=$(echo "$2" | sed -e 's/.*github.com[:\/]\(.*\)\.git/\1/')
```

`.git`がない場合、置換が失敗してURLがそのままrepo_nameに残る

### 修正後
```bash
repo_name=$(echo "$2" | sed -e 's/.*github.com[:\/]//' -e 's/\.git$//' -e 's/\/$//')
```

1. `github.com:`または`github.com/`までを除去
2. 末尾の`.git`があれば除去（任意）
3. 末尾スラッシュも除去

## 動作確認

以下のすべての形式が正しく`owner/repo`に変換されます：
- `https://github.com/owner/repo` → `owner/repo`
- `https://github.com/owner/repo.git` → `owner/repo`
- `https://github.com/owner/repo/` → `owner/repo`
- `git@github.com:owner/repo.git` → `owner/repo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* GitHub リポジトリ URL の処理ロジックを改善しました。`.git` 拡張子がない URL や末尾にスラッシュがある URL も正しく処理できるようになり、より多くの URL 形式に対応しました。この改善により、リポジトリのクローン処理がより堅牢で信頼できるものになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->